### PR TITLE
Enhance marketing site layout, metadata, and product flows

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import { Orbitron, Inter } from "next/font/google";
+import { SiteHeader } from "@/components/SiteHeader";
+import { SiteFooter } from "@/components/SiteFooter";
+import { GlobalStructuredData } from "@/components/StructuredData";
 
 const orbitron = Orbitron({
   subsets: ["latin"],
@@ -15,8 +18,49 @@ const inter = Inter({
 });
 
 export const metadata: Metadata = {
-  title: "Pigeonhole Streaming",
-  description: "Retro-futuristic streaming hardware marketplace"
+  metadataBase: new URL("https://mz1312.xx.kg"),
+  title: {
+    default: "Pigeonhole Streaming",
+    template: "%s | Pigeonhole Streaming"
+  },
+  description: "Retro-futuristic streaming hardware tuned for cinema obsessives.",
+  keywords: [
+    "streaming hardware",
+    "home theater",
+    "4K media player",
+    "retro futurism",
+    "Pigeonhole streaming"
+  ],
+  openGraph: {
+    type: "website",
+    url: "https://mz1312.xx.kg",
+    siteName: "Pigeonhole Streaming",
+    title: "Pigeonhole Streaming",
+    description: "Retro-futuristic streaming hardware tuned for cinema obsessives.",
+    images: [
+      {
+        url: "https://mz1312.xx.kg/og-image.jpg",
+        width: 1200,
+        height: 630,
+        alt: "Pigeonhole Streaming neon devices"
+      }
+    ]
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Pigeonhole Streaming",
+    description: "Retro-futuristic streaming hardware tuned for cinema obsessives.",
+    images: ["https://mz1312.xx.kg/og-image.jpg"],
+    creator: "@pigeonhole"
+  },
+  alternates: {
+    canonical: "https://mz1312.xx.kg"
+  },
+  icons: {
+    icon: "/favicon.ico",
+    apple: "/apple-touch-icon.png"
+  },
+  themeColor: "#0ff"
 };
 
 export default function RootLayout({
@@ -27,10 +71,21 @@ export default function RootLayout({
   return (
     <html lang="en" className={`${orbitron.variable} ${inter.variable}`} suppressHydrationWarning>
       <body className="min-h-screen bg-crt-screen text-white antialiased">
+        <GlobalStructuredData siteUrl="https://mz1312.xx.kg" />
+        <a
+          href="#main-content"
+          className="absolute left-4 top-4 z-50 -translate-y-full rounded bg-cyber-teal px-3 py-2 text-xs font-semibold text-black focus:translate-y-0"
+        >
+          Skip to main content
+        </a>
         <div className="absolute inset-0 -z-10 bg-grid bg-[length:40px_40px] opacity-40" />
-        <main className="relative flex min-h-screen flex-col items-center justify-start gap-16 px-6 py-10 sm:px-12">
-          {children}
-        </main>
+        <div className="relative flex min-h-screen w-full flex-col items-center gap-12 px-6 py-10 sm:px-12">
+          <SiteHeader />
+          <main id="main-content" className="flex w-full flex-1 flex-col items-center gap-16">
+            {children}
+          </main>
+          <SiteFooter />
+        </div>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,11 +2,13 @@ import { HeroSection } from "@/components/HeroSection";
 import { ProductGrid } from "@/components/ProductCard";
 import { TelegramSupport } from "@/components/TelegramSupport";
 import { BitcoinPayment } from "@/components/BitcoinPayment";
+import { PerformanceHighlights } from "@/components/PerformanceHighlights";
 
 export default function HomePage() {
   return (
     <div className="flex w-full max-w-6xl flex-col gap-16">
       <HeroSection />
+      <PerformanceHighlights />
       <ProductGrid />
       <div className="grid gap-8 md:grid-cols-2">
         <TelegramSupport />

--- a/app/podcast/[id]/page.tsx
+++ b/app/podcast/[id]/page.tsx
@@ -1,9 +1,46 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { getEpisodeById } from "@/lib/podcast";
+import { getEpisodeById, episodes } from "@/lib/podcast";
 import { PodcastPlayer } from "@/components/PodcastPlayer";
+import { PodcastStructuredData } from "@/components/StructuredData";
+
+const siteUrl = "https://mz1312.xx.kg";
 
 interface PodcastPageProps {
   params: { id: string };
+}
+
+export function generateStaticParams() {
+  return episodes.map((episode) => ({ id: episode.id }));
+}
+
+export function generateMetadata({ params }: PodcastPageProps): Metadata {
+  const episode = getEpisodeById(params.id);
+
+  if (!episode) {
+    return {
+      title: "Episode not found"
+    };
+  }
+
+  const canonical = `${siteUrl}/podcast/${episode.id}`;
+
+  return {
+    title: `${episode.title} · Signal Boost Podcast`,
+    description: episode.description,
+    alternates: { canonical },
+    openGraph: {
+      type: "article",
+      url: canonical,
+      title: episode.title,
+      description: episode.description
+    },
+    twitter: {
+      card: "summary",
+      title: episode.title,
+      description: episode.description
+    }
+  };
 }
 
 export default function PodcastPage({ params }: PodcastPageProps) {
@@ -15,6 +52,7 @@ export default function PodcastPage({ params }: PodcastPageProps) {
 
   return (
     <div className="mx-auto flex w-full max-w-4xl flex-col gap-8">
+      <PodcastStructuredData episode={episode} siteUrl={siteUrl} />
       <header className="glitch-border rounded-3xl bg-crt-glass/70 p-6 text-center">
         <h1 className="font-orbitron text-3xl uppercase tracking-[0.3em] text-cyber-pink">Signal Boost Podcast</h1>
         <p className="mt-2 text-sm text-cyber-teal/70">Episode {episode.id} · Published {episode.publishedAt}</p>

--- a/app/products/[slug]/page.tsx
+++ b/app/products/[slug]/page.tsx
@@ -1,12 +1,51 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Image from "next/image";
-import { getProductBySlug } from "@/lib/products";
+import { getProductBySlug, products } from "@/lib/products";
 import { CompatibilityBadges } from "@/components/CompatibilityBadges";
 import { TMDBPreview } from "@/components/TMDBPreview";
-import { Button } from "@/components/ui/button";
+import { CheckoutButton } from "@/components/CheckoutButton";
+import { ProductStructuredData } from "@/components/StructuredData";
+
+const siteUrl = "https://mz1312.xx.kg";
 
 interface ProductPageProps {
   params: { slug: string };
+}
+
+export function generateStaticParams() {
+  return products.map((product) => ({ slug: product.slug }));
+}
+
+export function generateMetadata({ params }: ProductPageProps): Metadata {
+  const product = getProductBySlug(params.slug);
+
+  if (!product) {
+    return {
+      title: "Product not found"
+    };
+  }
+
+  const canonical = `${siteUrl}/products/${product.slug}`;
+
+  return {
+    title: product.name,
+    description: product.description,
+    alternates: { canonical },
+    openGraph: {
+      type: "product",
+      url: canonical,
+      title: product.name,
+      description: product.description,
+      images: [{ url: `${siteUrl}${product.image}`, width: 1200, height: 675, alt: product.name }]
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: product.name,
+      description: product.description,
+      images: [`${siteUrl}${product.image}`]
+    }
+  };
 }
 
 export default function ProductPage({ params }: ProductPageProps) {
@@ -18,6 +57,7 @@ export default function ProductPage({ params }: ProductPageProps) {
 
   return (
     <div className="mx-auto flex w-full max-w-5xl flex-col gap-12">
+      <ProductStructuredData product={product} siteUrl={siteUrl} />
       <header className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
         <div className="space-y-4">
           <h1 className="font-orbitron text-4xl uppercase tracking-[0.4em] text-cyber-pink">{product.name}</h1>
@@ -45,11 +85,7 @@ export default function ProductPage({ params }: ProductPageProps) {
           <div className="glitch-border rounded-3xl bg-black/50 p-6 text-sm text-white/80">
             <p>Price</p>
             <p className="font-orbitron text-2xl text-cyber-pink">{product.price}</p>
-            <form action={`/api/checkout/${product.id}`} method="post" className="mt-4">
-              <Button type="submit" className="w-full">
-                Initiate Checkout
-              </Button>
-            </form>
+            <CheckoutButton productId={product.id} productName={product.name} />
           </div>
         </aside>
       </section>

--- a/components/CheckoutButton.tsx
+++ b/components/CheckoutButton.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { CheckCircle2, Loader2, TriangleAlert } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface CheckoutButtonProps {
+  productId: string;
+  productName: string;
+}
+
+export function CheckoutButton({ productId, productName }: CheckoutButtonProps) {
+  const [message, setMessage] = useState<string | null>(null);
+  const [status, setStatus] = useState<"idle" | "success" | "error">("idle");
+  const [isPending, startTransition] = useTransition();
+
+  const handleCheckout = () => {
+    startTransition(async () => {
+      try {
+        setStatus("idle");
+        setMessage(null);
+        const response = await fetch(`/api/checkout/${productId}`, {
+          method: "POST"
+        });
+
+        if (!response.ok) {
+          throw new Error("Failed to initiate checkout");
+        }
+
+        const payload = (await response.json()) as { reference: string; message: string; paymentUrl: string };
+        setStatus("success");
+        setMessage(`${payload.message} Reference: ${payload.reference}.`);
+        window.open(payload.paymentUrl, "_blank", "noopener,noreferrer");
+      } catch (error) {
+        console.error(error);
+        setStatus("error");
+        setMessage("Unable to reach the checkout node. Please retry in a moment.");
+      }
+    });
+  };
+
+  return (
+    <div className="space-y-4">
+      <Button className="w-full" onClick={handleCheckout} disabled={isPending || status === "success"}>
+        {isPending ? (
+          <span className="flex items-center gap-2 text-xs uppercase tracking-[0.3em]">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Initializing Checkout
+          </span>
+        ) : (
+          <>Initiate Checkout</>
+        )}
+      </Button>
+      <AnimatePresence>
+        {message && (
+          <motion.div
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 10 }}
+            className="glitch-border flex items-start gap-3 rounded-2xl bg-black/60 p-4 text-xs text-white/80"
+          >
+            {status === "success" ? (
+              <CheckCircle2 className="mt-[2px] h-4 w-4 text-cyber-lime" />
+            ) : (
+              <TriangleAlert className="mt-[2px] h-4 w-4 text-cyber-pink" />
+            )}
+            <div>
+              <p className="font-orbitron uppercase tracking-[0.3em] text-cyber-teal">{productName}</p>
+              <p>{message}</p>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -1,22 +1,24 @@
 "use client";
 
 import { motion } from "framer-motion";
+import Image from "next/image";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
 
 export function HeroSection() {
   return (
-    <section className="relative flex w-full flex-col gap-12 overflow-hidden rounded-3xl border border-cyber-pink/50 bg-crt-glass/60 p-10 text-center shadow-glitch">
-      <div className="absolute inset-0 -z-10 opacity-30">
-        <motion.img
-          src="/crt-pigeon.svg"
-          alt="CRT pigeon silhouette"
-          className="h-full w-full object-cover"
-          initial={{ scale: 1.1, opacity: 0 }}
-          animate={{ scale: 1, opacity: 1 }}
-          transition={{ duration: 1.4, ease: "easeOut" }}
-        />
-      </div>
+    <section
+      id="hero"
+      className="relative flex w-full flex-col gap-12 overflow-hidden rounded-3xl border border-cyber-pink/50 bg-crt-glass/60 p-10 text-center shadow-glitch"
+    >
+      <motion.div
+        className="absolute inset-0 -z-10 opacity-30"
+        initial={{ scale: 1.08, opacity: 0 }}
+        animate={{ scale: 1, opacity: 1 }}
+        transition={{ duration: 1.4, ease: "easeOut" }}
+      >
+        <Image src="/crt-pigeon.svg" alt="CRT pigeon silhouette" fill priority className="object-cover" sizes="100vw" />
+      </motion.div>
       <motion.h1
         className="font-orbitron text-4xl uppercase tracking-[0.4em] sm:text-5xl"
         initial={{ opacity: 0, y: 30 }}
@@ -68,6 +70,9 @@ export function HeroSection() {
         </Button>
         <Button variant="ghost" asChild>
           <Link href="/podcast/001">Listen to the Signal</Link>
+        </Button>
+        <Button variant="outline" asChild>
+          <Link href="/about">Meet the Collective</Link>
         </Button>
       </motion.div>
     </section>

--- a/components/PerformanceHighlights.tsx
+++ b/components/PerformanceHighlights.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { Gauge, HardDriveDownload, ShieldCheck } from "lucide-react";
+
+const highlights = [
+  {
+    icon: Gauge,
+    title: "Latency Lab Tested",
+    description: "Each device ships with firmware tuned to keep response times under 40ms for the most demanding streaming apps."
+  },
+  {
+    icon: HardDriveDownload,
+    title: "Instant Library Sync",
+    description: "TMDB playlists, Dolby Vision profiles, and calibration LUTs load in seconds with our zero-buffer provisioning pipeline."
+  },
+  {
+    icon: ShieldCheck,
+    title: "Fail-Safe Rollbacks",
+    description: "Snapshot restores and encrypted diagnostics ensure perfect uptime across the entire pigeonhole fleet."
+  }
+];
+
+export function PerformanceHighlights() {
+  return (
+    <section className="flex w-full flex-col gap-8">
+      <div className="flex flex-col gap-2 text-left">
+        <h2 className="font-orbitron text-2xl uppercase tracking-[0.3em] text-cyber-teal">Why Perfection Matters</h2>
+        <p className="max-w-2xl text-sm text-cyber-teal/70">
+          Every chassis is battle tested in the Neon Lab to guarantee flawless playback, secure updates, and immersive cinematic
+          audio from day one.
+        </p>
+      </div>
+      <div className="grid gap-6 md:grid-cols-3">
+        {highlights.map((highlight) => (
+          <motion.article
+            key={highlight.title}
+            className="glitch-border flex flex-col gap-4 rounded-3xl bg-black/40 p-6"
+            initial={{ opacity: 0, y: 16 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.4 }}
+          >
+            <highlight.icon className="h-8 w-8 text-cyber-pink" />
+            <h3 className="font-orbitron text-lg uppercase tracking-[0.3em] text-white">{highlight.title}</h3>
+            <p className="text-sm text-cyber-teal/80">{highlight.description}</p>
+          </motion.article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/PodcastPlayer.tsx
+++ b/components/PodcastPlayer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { Play, Waves } from "lucide-react";
+import { Waves } from "lucide-react";
 
 interface PodcastPlayerProps {
   title: string;
@@ -18,29 +18,33 @@ export function PodcastPlayer({ title, description, duration, audioUrl }: Podcas
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.5 }}
     >
-      <div className="flex items-center gap-3">
-        <div className="flex h-12 w-12 items-center justify-center rounded-full border border-cyber-teal/40 bg-black/50">
-          <Play className="h-6 w-6 text-cyber-pink" />
-        </div>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h2 className="font-orbitron text-lg uppercase tracking-[0.3em] text-cyber-teal">{title}</h2>
           <p className="text-xs text-white/70">Duration: {duration}</p>
         </div>
+        <a
+          href={audioUrl}
+          className="text-[11px] uppercase tracking-[0.35em] text-cyber-pink underline-offset-4 hover:underline"
+        >
+          Download Episode
+        </a>
       </div>
       <p className="text-sm text-cyber-teal/80">{description}</p>
       <div className="flex items-center gap-2 text-xs text-white/50">
         <Waves className="h-4 w-4 text-cyber-lime" />
-        <span>Streaming a simulated feed from: {audioUrl}</span>
+        <span>Streaming from: {new URL(audioUrl).hostname}</span>
       </div>
-      <button
-        type="button"
-        className="glitch-border relative overflow-hidden rounded-2xl bg-gradient-to-r from-cyber-pink/40 via-cyber-teal/40 to-cyber-lime/40 px-5 py-3 text-xs uppercase tracking-[0.4em]"
-        onClick={() => {
-          console.info("Pretend to play", audioUrl);
-        }}
+      <audio
+        controls
+        preload="none"
+        src={audioUrl}
+        className="w-full rounded-2xl bg-black/60"
+        aria-label={`Play ${title}`}
       >
-        Engage Playback
-      </button>
+        Your browser does not support the audio element. You can
+        <a href={audioUrl}> download the episode instead.</a>
+      </audio>
     </motion.section>
   );
 }

--- a/components/PodcastPlayer.tsx
+++ b/components/PodcastPlayer.tsx
@@ -43,7 +43,7 @@ export function PodcastPlayer({ title, description, duration, audioUrl }: Podcas
         aria-label={`Play ${title}`}
       >
         Your browser does not support the audio element. You can
-        <a href={audioUrl}> download the episode instead.</a>
+        <a href={audioUrl} target="_blank" rel="noopener noreferrer"> download the episode instead.</a>
       </audio>
     </motion.section>
   );

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import { motion } from "framer-motion";
+import Image from "next/image";
 import Link from "next/link";
 import { products, type Product } from "@/lib/products";
 import { CompatibilityBadges } from "@/components/CompatibilityBadges";
 
 export function ProductGrid() {
   return (
-    <section className="flex w-full flex-col gap-10">
+    <section id="devices" className="flex w-full flex-col gap-10">
       <div className="flex flex-col gap-2 text-left">
         <h2 className="font-orbitron text-3xl uppercase tracking-[0.3em] text-cyber-pink">Device Lineup</h2>
         <p className="max-w-2xl text-cyber-teal/70">
@@ -32,23 +33,27 @@ interface ProductCardProps {
 export function ProductCard({ product, index }: ProductCardProps) {
   return (
     <motion.article
-      className="glitch-border flex flex-col gap-6 rounded-3xl bg-crt-glass/70 p-6"
+      className="group glitch-border flex flex-col gap-6 rounded-3xl bg-crt-glass/70 p-6"
       initial={{ opacity: 0, y: 20 }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
       transition={{ delay: index * 0.08 }}
     >
-      <div className="relative overflow-hidden rounded-2xl border border-cyber-teal/40">
-        <motion.img
+      <motion.div
+        className="relative overflow-hidden rounded-2xl border border-cyber-teal/40"
+        initial={{ scale: 1.02 }}
+        whileHover={{ scale: 1.05 }}
+        transition={{ type: "spring", stiffness: 120 }}
+      >
+        <Image
           src={product.image}
           alt={product.name}
-          className="h-40 w-full object-cover"
-          initial={{ scale: 1.1 }}
-          whileHover={{ scale: 1.2 }}
-          transition={{ type: "spring", stiffness: 120 }}
+          fill
+          className="object-cover transition-transform duration-500 group-hover:scale-110"
+          sizes="(max-width: 768px) 100vw, 320px"
         />
         <div className="scanlines absolute inset-0" />
-      </div>
+      </motion.div>
       <div className="flex flex-col gap-3">
         <h3 className="font-orbitron text-xl uppercase tracking-[0.2em] text-cyber-lime">{product.name}</h3>
         <p className="text-sm text-cyber-teal/70">{product.tagline}</p>
@@ -66,7 +71,7 @@ export function ProductCard({ product, index }: ProductCardProps) {
         <span className="font-orbitron text-lg">{product.price}</span>
         <Link
           href={`/products/${product.slug}`}
-          className="font-orbitron text-xs uppercase tracking-[0.3em] text-cyber-teal hover:text-cyber-pink"
+          className="font-orbitron text-xs uppercase tracking-[0.3em] text-cyber-teal transition hover:text-cyber-pink"
         >
           View Specs
         </Link>

--- a/components/SiteFooter.tsx
+++ b/components/SiteFooter.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+
+export function SiteFooter() {
+  return (
+    <footer className="w-full max-w-6xl rounded-3xl border border-cyber-teal/30 bg-black/60 p-8 text-sm text-cyber-teal/70">
+      <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+        <div className="space-y-2">
+          <p className="font-orbitron text-xs uppercase tracking-[0.4em] text-cyber-pink">Pigeonhole Streaming</p>
+          <p className="max-w-md text-xs text-white/60">
+            Retro-futuristic streaming fleet engineered for perfect signal integrity and neon-lit living rooms. Built by firmware
+            artists who obsess over latency, color science, and cinematic sound.
+          </p>
+        </div>
+        <div className="flex flex-col gap-2 text-xs uppercase tracking-[0.35em] text-cyber-teal">
+          <Link className="transition hover:text-cyber-pink" href="mailto:hello@pigeonhole.dev">
+            hello@pigeonhole.dev
+          </Link>
+          <Link className="transition hover:text-cyber-pink" href="https://t.me/pigeonhole-support" target="_blank" rel="noreferrer">
+            Telegram Support
+          </Link>
+          <Link className="transition hover:text-cyber-pink" href="/about">
+            Company Manifesto
+          </Link>
+        </div>
+      </div>
+      <div className="mt-6 flex flex-wrap items-center justify-between gap-4 text-[10px] uppercase tracking-[0.35em] text-white/40">
+        <span>© {new Date().getFullYear()} Pigeonhole Collective</span>
+        <span>Optimized for 4K HDR · Zero Buffer Pledge</span>
+      </div>
+    </footer>
+  );
+}

--- a/components/SiteHeader.tsx
+++ b/components/SiteHeader.tsx
@@ -1,0 +1,34 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+const navigation = [
+  { href: "/#devices", label: "Devices" },
+  { href: "/podcast/001", label: "Podcast" },
+  { href: "/about", label: "About" }
+];
+
+export function SiteHeader() {
+  return (
+    <header className="sticky top-0 z-40 w-full max-w-6xl rounded-full border border-cyber-teal/40 bg-black/70 backdrop-blur">
+      <div className="flex flex-wrap items-center justify-between gap-4 px-6 py-4">
+        <Link href="/" className="font-orbitron text-sm uppercase tracking-[0.4em] text-cyber-pink">
+          Pigeonhole Streaming
+        </Link>
+        <nav aria-label="Primary" className="flex flex-1 items-center justify-center gap-6 text-[11px] uppercase tracking-[0.35em]">
+          {navigation.map((item) => (
+            <Link key={item.href} href={item.href} className="text-cyber-teal/80 transition hover:text-cyber-pink">
+              {item.label}
+            </Link>
+          ))}
+        </nav>
+        <div className="flex items-center gap-3">
+          <Button asChild size="sm">
+            <Link href="https://t.me/pigeonhole-support" target="_blank" rel="noreferrer">
+              Talk to an Engineer
+            </Link>
+          </Button>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/components/StructuredData.tsx
+++ b/components/StructuredData.tsx
@@ -1,0 +1,113 @@
+interface GlobalStructuredDataProps {
+  siteUrl: string;
+}
+
+export function GlobalStructuredData({ siteUrl }: GlobalStructuredDataProps) {
+  const data = {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: "Pigeonhole Streaming",
+    url: siteUrl,
+    sameAs: ["https://t.me/pigeonhole-support"],
+    slogan: "Retro-futuristic streaming hardware tuned for perfect neon cinema.",
+    contactPoint: [
+      {
+        "@type": "ContactPoint",
+        contactType: "customer support",
+        areaServed: "Worldwide",
+        availableLanguage: ["English"],
+        email: "hello@pigeonhole.dev"
+      }
+    ]
+  };
+
+  return (
+    <script type="application/ld+json" suppressHydrationWarning dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }} />
+  );
+}
+
+interface ProductStructuredDataProps {
+  product: {
+    name: string;
+    description: string;
+    price: string;
+    image: string;
+    compatibility: string[];
+    slug: string;
+  };
+  siteUrl: string;
+}
+
+export function ProductStructuredData({ product, siteUrl }: ProductStructuredDataProps) {
+  const priceValue = Number(product.price.replace(/[^0-9.]/g, ""));
+  const data = {
+    "@context": "https://schema.org",
+    "@type": "Product",
+    name: product.name,
+    description: product.description,
+    image: `${siteUrl}${product.image}`,
+    sku: product.slug,
+    brand: {
+      "@type": "Brand",
+      name: "Pigeonhole Streaming"
+    },
+    offers: {
+      "@type": "Offer",
+      priceCurrency: "USD",
+      price: priceValue || undefined,
+      availability: "https://schema.org/PreOrder",
+      url: `${siteUrl}/products/${product.slug}`
+    },
+    additionalProperty: product.compatibility.map((item) => ({
+      "@type": "PropertyValue",
+      name: "Compatibility",
+      value: item
+    }))
+  };
+
+  return (
+    <script type="application/ld+json" suppressHydrationWarning dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }} />
+  );
+}
+
+interface PodcastStructuredDataProps {
+  episode: {
+    id: string;
+    title: string;
+    description: string;
+    audioUrl: string;
+    publishedAt: string;
+    duration: string;
+  };
+  siteUrl: string;
+}
+
+export function PodcastStructuredData({ episode, siteUrl }: PodcastStructuredDataProps) {
+  const [minutes, seconds = 0] = episode.duration.split(":").map(Number);
+  const isoDuration = `PT${minutes || 0}M${seconds || 0}S`;
+
+  const data = {
+    "@context": "https://schema.org",
+    "@type": "PodcastEpisode",
+    name: episode.title,
+    description: episode.description,
+    url: `${siteUrl}/podcast/${episode.id}`,
+    datePublished: episode.publishedAt,
+    duration: isoDuration,
+    episodeNumber: Number(episode.id),
+    partOfSeries: {
+      "@type": "PodcastSeries",
+      name: "Signal Boost Podcast",
+      url: `${siteUrl}/podcast/${episode.id}`
+    },
+    audio: {
+      "@type": "AudioObject",
+      contentUrl: episode.audioUrl,
+      encodingFormat: "audio/mpeg"
+    }
+  };
+
+  return (
+    <script type="application/ld+json" suppressHydrationWarning dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }} />
+  );
+}


### PR DESCRIPTION
## Summary
- add sticky navigation, detailed footer, and SEO-friendly metadata/structured data for stronger branding
- optimize hero and product imagery, highlight performance pillars, and surface interactive checkout flow
- ship accessible podcast player with audio controls plus richer metadata for product and podcast pages

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce68b176488333892b37fa5b796f22